### PR TITLE
Add prometheus rules for image stream tags rules

### DIFF
--- a/manifests/09-prometheus-rules-imagestreams.yaml
+++ b/manifests/09-prometheus-rules-imagestreams.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: imagestreams-rules
+  namespace: openshift-image-registry
+spec:
+  groups:
+  - name: imagestreams.rules
+    rules:
+    - expr: sum by (location, source) (image_registry_image_stream_tags_total)
+      record: imagestreamtags:count:sum


### PR DESCRIPTION
To make the backport process easier I opted to include these changes in your PR instead of creating a new one directly on top of upstream. Let me know what you think.

Create a record rule to collect the amount of image stream tags present
in the cluster.