### PR TITLE
Documenting imagestreamtags metrics

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -6,3 +6,10 @@
 | --------- | -------------- |
 | `get`     | blob\|manifest |
 | `create`  | blob\|manifest |
+
+## `imageregistry:imagestreamtags_count:sum`
+
+| Source     | Location         | Description                                                     |
+| ---------- | ---------------- | --------------------------------------------------------------- |
+| `imported` | openshift\|other | Image Stream Tags imported in 'openshift' or 'other' namespaces |
+| `pushed`   | openshift\|other | Image Stream Tags pushed to 'openshift' or 'other' namespaces   |


### PR DESCRIPTION
Adding documentation for the following Prometheus Rule:

imageregistry:imagestreamtags_count:sum